### PR TITLE
ENH enable loading private data

### DIFF
--- a/download_data.py
+++ b/download_data.py
@@ -1,3 +1,4 @@
+import click
 import os
 from osfclient.api import OSF
 
@@ -15,20 +16,37 @@ from osfclient.api import OSF
 LOCAL_PATH = 'data'  # local path to the data
 REMOTE_PATH = 'MEG/'  # remote path where to store the data on OSF
 PROJECT_CODE = 't4uf8'  # to find your PROJECT_CODE navigate to your OSF
+PROJECT_CODE_PRIVATE = 'vw8sh'
 # project on the web. The link will be something of this type:
 # https://osf.io/t4uf8/ , here t4uf8 is the PROJECT_CODE
 
-# if the file already exists it will overwrite it
-# osf = OSF(username=USERNAME, password=PASSWORD)
-osf = OSF()
-project = osf.project(PROJECT_CODE)
 
-destination = 'https://osf.io/' + PROJECT_CODE + '/'
-store = project.storage('osfstorage')
-
-
-def download_from_osf():
+@click.command()
+@click.option("--private", is_flag=True)
+@click.option(
+    "--username",
+    help="Your username to the private repository"
+)
+@click.option(
+    "--password",
+    help="Your password to the private repository"
+)
+def download_from_osf(private, username, password):
     file_idx = 0
+    if private:
+        project_code = PROJECT_CODE_PRIVATE
+    else:
+        project_code = PROJECT_CODE
+
+    # if the file already exists it will overwrite it
+    # osf = OSF(username=USERNAME, password=PASSWORD)
+    if private:
+        osf = OSF(username=username, password=password)
+    else:
+        osf = OSF()
+    project = osf.project(project_code)
+    store = project.storage('osfstorage')
+
     for file_ in store.files:
         # get only those files which are stored in REMOTE_PATH
         pathname = file_.path

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+click
 ramp-workflow
 ramp-utils
 numpy


### PR DESCRIPTION
Enabled click option to be run from command line:
if option set to `--private` the options `--username` and `--password` must also be given with the coords to the private osf repo
if the option `--private` is not chosen the public dataset will be downloaded
if run from python, eg: `python download_data.py` the public dataset will be downloaded

cc @agramfort @tomMoral